### PR TITLE
Include Babel configuration in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 .DS_Store
 .env
 .npm/
+.npmrc
 .vscode/
 dist/
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ then \
     && npm cache clean --force 2> /dev/null \
 ; fi
 
-ADD ./src/ /srv/src/
+ADD ./ /srv/
 
 # After building the application, remove the `devDependencies`
 # for when NODE_ENV is "production".


### PR DESCRIPTION
De Docker build gaf foutmeldingen over de Babel conversie van ES6 naar ES5:

```
Add @babel/plugin-proposal-class-properties (https://git.io/vb4SL) to the 'plugins' section of your Babel config to enable transformation.
```

Deze optie stond wel in de `.babelrc` config, maar die file werd niet ge-`ADD` in Docker. Nu wel!