### PR TITLE
Switch from import to require

### DIFF
--- a/src/views/AanmeldPage.jsx
+++ b/src/views/AanmeldPage.jsx
@@ -1,9 +1,9 @@
-import Content from './components/Content';
+const Content = require('./components/Content');
 const React = require('react');
 const Page = require('./components/Page.jsx');
 const PropTypes = require('prop-types');
 const AanmeldForm = require('./components/AanmeldForm.jsx');
-import Header from './components/Header';
+const Header = require('./components/Header');
 
 class AanmeldPage extends React.Component {
     propTypes = {

--- a/src/views/AfmeldPage.jsx
+++ b/src/views/AfmeldPage.jsx
@@ -1,10 +1,9 @@
-import Content from './components/Content';
-
+const Content = require('./components/Content');
 const React = require('react');
 const Page = require('./components/Page.jsx');
 const AfmeldForm = require('./components/AfmeldForm.jsx');
 const PropTypes = require('prop-types');
-import Header from './components/Header';
+const Header = require('./components/Header');
 
 class AfmeldPage extends React.Component {
     propTypes = {

--- a/src/views/MarktDetailPage.jsx
+++ b/src/views/MarktDetailPage.jsx
@@ -1,9 +1,9 @@
-import { addDays, DAYS_IN_WEEK, formatDayOfWeek, formatMonth, nextWeek, tomorrow } from '../util.js';
+const { addDays, DAYS_IN_WEEK, formatDayOfWeek, formatMonth, nextWeek, tomorrow } = require('../util.js');
 const React = require('react');
 const PropTypes = require('prop-types');
 const MarktDetailBase = require('./components/MarktDetailBase');
 const today = () => new Date().toISOString().replace(/T.+/, '');
-import { getUpcomingMarktDays, parseMarktDag } from '../domain-knowledge.js';
+const { getUpcomingMarktDays, parseMarktDag } = require('../domain-knowledge.js');
 
 class MarktDetailPage extends React.Component {
     propTypes = {

--- a/src/views/ProfilePage.jsx
+++ b/src/views/ProfilePage.jsx
@@ -1,10 +1,10 @@
-import Content from './components/Content';
+const Content = require('./components/Content');
 const React = require('react');
 const Page = require('./components/Page.jsx');
 const PropTypes = require('prop-types');
 const OndernemerProfile = require('./components/OndernemerProfile.jsx');
 const MarktmeesterProfile = require('./components/MarktmeesterProfile.jsx');
-import Header from './components/Header';
+const Header = require('./components/Header');
 
 const today = () => new Date().toISOString().replace(/T.+/, '');
 

--- a/src/views/PublicProfilePage.jsx
+++ b/src/views/PublicProfilePage.jsx
@@ -1,10 +1,10 @@
-import Content from './components/Content';
+const Content = require('./components/Content');
 const React = require('react');
 const Page = require('./components/Page.jsx');
 const PropTypes = require('prop-types');
 const OndernemerProfile = require('./components/OndernemerProfile.jsx');
 const MarktmeesterProfile = require('./components/MarktmeesterProfile.jsx');
-import Header from './components/Header';
+const Header = require('./components/Header');
 
 const { isVast } = require('../domain-knowledge.js');
 

--- a/src/views/SollicitantenPage.jsx
+++ b/src/views/SollicitantenPage.jsx
@@ -1,8 +1,7 @@
 const React = require('react');
-import MarktDetailBase from './components/MarktDetailBase';
-import OndernemerList from './components/OndernemerList';
-import PrintPage from './components/PrintPage';
-
+const MarktDetailBase = require('./components/MarktDetailBase');
+const OndernemerList = require('./components/OndernemerList');
+const PrintPage = require('./components/PrintPage');
 const PropTypes = require('prop-types');
 
 class SollicitantenPage extends React.Component {

--- a/src/views/VastplaatshoudersPage.jsx
+++ b/src/views/VastplaatshoudersPage.jsx
@@ -1,11 +1,11 @@
 const { arrayToObject } = require('../util.js');
-import IndelingslijstGroup from './components/IndelingslijstGroup';
+const IndelingslijstGroup = require('./components/IndelingslijstGroup');
 const React = require('react');
-import MarktDetailBase from './components/MarktDetailBase';
-import PrintPage from './components/PrintPage';
+const MarktDetailBase = require('./components/MarktDetailBase');
+const PrintPage = require('./components/PrintPage');
 const PropTypes = require('prop-types');
 const { ondernemersToLocatieKeyValue, obstakelsToLocatieKeyValue } = require('../domain-knowledge.js');
-import Street from './components/Street';
+const Street = require('./components/Street');
 
 class VastplaatshoudersPage extends React.Component {
     propTypes = {

--- a/src/views/VoorkeurenPage.jsx
+++ b/src/views/VoorkeurenPage.jsx
@@ -1,10 +1,9 @@
-import Content from './components/Content';
-
+const Content = require('./components/Content');
 const React = require('react');
 const Page = require('./components/Page.jsx');
 const PlaatsvoorkeurenForm = require('./components/PlaatsvoorkeurenForm.jsx');
 const PropTypes = require('prop-types');
-import Header from './components/Header';
+const Header = require('./components/Header');
 
 class VoorkeurenPage extends React.Component {
     propTypes = {

--- a/src/views/components/AfmeldForm.jsx
+++ b/src/views/components/AfmeldForm.jsx
@@ -1,4 +1,4 @@
-import OndernemerMarktHeading from './OndernemerMarktHeading';
+const OndernemerMarktHeading = require('./OndernemerMarktHeading');
 const React = require('react');
 const PropTypes = require('prop-types');
 const { formatDayOfWeek, MILLISECONDS_IN_DAY } = require('../../util.js');

--- a/src/views/components/Alert.jsx
+++ b/src/views/components/Alert.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const Alert = ({ type, message, title }) => {
     return (

--- a/src/views/components/Button.jsx
+++ b/src/views/components/Button.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const Button = ({ label, href, type }) => {
     return (

--- a/src/views/components/Content.jsx
+++ b/src/views/components/Content.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const Content = ({ children }) => {
     return (

--- a/src/views/components/Header.jsx
+++ b/src/views/components/Header.jsx
@@ -1,6 +1,6 @@
-import LoginButton from './LoginButton';
-import PropTypes from 'prop-types';
-import React from 'react';
+const LoginButton = require('./LoginButton');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const Header = ({ user }) => {
     return (

--- a/src/views/components/IndelingslijstGroup.jsx
+++ b/src/views/components/IndelingslijstGroup.jsx
@@ -1,8 +1,8 @@
-import ObstakelList from './ObstakelList';
-import Plaats from './Plaats';
-import PlaatsVPH from './PlaatsVPH';
-import PropTypes from 'prop-types';
-import React from 'react';
+const ObstakelList = require('./ObstakelList');
+const Plaats = require('./Plaats');
+const PlaatsVPH = require('./PlaatsVPH');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const IndelingslijstGroup = ({ page, plaatsList, vphl, obstakelList, markt, aanmeldingen, type, datum }) => {
     let first = true;

--- a/src/views/components/LoginButton.jsx
+++ b/src/views/components/LoginButton.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const LoginButton = ({ user }) => {
     return (

--- a/src/views/components/MarktDayLink.jsx
+++ b/src/views/components/MarktDayLink.jsx
@@ -1,7 +1,7 @@
-import { addDays, DAYS_IN_WEEK, formatDayOfWeek } from '../../util.js';
-import { getMarktDays, parseMarktDag } from '../../domain-knowledge.js';
-import PropTypes from 'prop-types';
-import React from 'react';
+const { addDays, DAYS_IN_WEEK, formatDayOfWeek } = require('../../util.js');
+const { getMarktDays, parseMarktDag } = require('../../domain-knowledge.js');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const MarktDayLink = ({ markt, offsetDate, direction = 1 }) => {
     let targetDate, startDate, endDate;

--- a/src/views/components/MarktDetailBase.jsx
+++ b/src/views/components/MarktDetailBase.jsx
@@ -3,10 +3,10 @@ const Page = require('./Page.jsx');
 const Header = require('./Header');
 const Content = require('./Content');
 const PropTypes = require('prop-types');
-import { formatDayOfWeek, formatMonth } from '../../util';
-import MarktDayLink from './MarktDayLink';
-import MarktDetailHeader from './MarktDetailHeader';
-import PrintButton from './PrintButton';
+const { formatDayOfWeek, formatMonth } = require('../../util');
+const MarktDayLink = require('./MarktDayLink');
+const MarktDetailHeader = require('./MarktDetailHeader');
+const PrintButton = require('./PrintButton');
 
 const MarktDetailBase = ({ children, bodyClass, title, markt, type, datum, user, showDate }) => {
     const relativeDatum = d => {

--- a/src/views/components/MarktDetailHeader.jsx
+++ b/src/views/components/MarktDetailHeader.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const MarktDetailHeader = ({ children }) => {
     return (

--- a/src/views/components/MarktList.jsx
+++ b/src/views/components/MarktList.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 const today = () => new Date().toISOString().replace(/T.+/, '');
 
 const MarktList = ({ markten }) => {

--- a/src/views/components/Obstakel.jsx
+++ b/src/views/components/Obstakel.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const icons = ['loopjediedichtmag', 'lantaarnpaal', 'bankje', 'boom', 'electra'];
 

--- a/src/views/components/ObstakelList.jsx
+++ b/src/views/components/ObstakelList.jsx
@@ -1,6 +1,6 @@
-import Obstakel from './Obstakel';
-import PropTypes from 'prop-types';
-import React from 'react';
+const Obstakel = require('./Obstakel');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const ObstakelList = ({ obstakelList }) => {
     // console.log(obstakelList);

--- a/src/views/components/OndernemerAanwezigheid.jsx
+++ b/src/views/components/OndernemerAanwezigheid.jsx
@@ -1,6 +1,6 @@
-import OndernemerMarktAanwezigheid from './OndernemerMarktAanwezigheid';
-import PropTypes from 'prop-types';
-import React from 'react';
+const OndernemerMarktAanwezigheid = require('./OndernemerMarktAanwezigheid');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const { getMarktDays, parseMarktDag, filterRsvpList } = require('../../domain-knowledge.js');
 

--- a/src/views/components/OndernemerList.jsx
+++ b/src/views/components/OndernemerList.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const today = () => new Date().toISOString().replace(/T.+/, '');
 

--- a/src/views/components/OndernemerMarktAanwezigheid.jsx
+++ b/src/views/components/OndernemerMarktAanwezigheid.jsx
@@ -1,7 +1,7 @@
-import Button from './Button';
-import OndernemerMarktHeading from './OndernemerMarktHeading';
-import PropTypes from 'prop-types';
-import React from 'react';
+const Button = require('./Button');
+const OndernemerMarktHeading = require('./OndernemerMarktHeading');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const { formatDayOfWeek } = require('../../util.js');
 

--- a/src/views/components/OndernemerMarktHeading.jsx
+++ b/src/views/components/OndernemerMarktHeading.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const OndernemerMarktHeading = ({ markt, sollicitatie }) => {
     return (

--- a/src/views/components/OndernemerProfileHeader.jsx
+++ b/src/views/components/OndernemerProfileHeader.jsx
@@ -1,6 +1,6 @@
-import ProfilePhoto from './ProfilePhoto';
-import PropTypes from 'prop-types';
-import React from 'react';
+const ProfilePhoto = require('./ProfilePhoto');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const OndernemerProfileHeader = ({ user }) => {
     return (

--- a/src/views/components/Plaats.jsx
+++ b/src/views/components/Plaats.jsx
@@ -1,6 +1,6 @@
-import PrintableBackground from './PrintableBackground';
-import PropTypes from 'prop-types';
-import React from 'react';
+const PrintableBackground = require('./PrintableBackground');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const Plaats = ({ plaats, vph, first, aanmelding, markt, datum, type }) => {
     const colorList = {

--- a/src/views/components/PlaatsVPH.jsx
+++ b/src/views/components/PlaatsVPH.jsx
@@ -1,6 +1,6 @@
-import PrintableBackground from './PrintableBackground';
-import PropTypes from 'prop-types';
-import React from 'react';
+const PrintableBackground = require('./PrintableBackground');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const PlaatsVPH = ({ plaats, vph, first, aanmelding, markt, datum, type }) => {
     const colorList = {

--- a/src/views/components/PrintButton.jsx
+++ b/src/views/components/PrintButton.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const PrintButton = ({ title, type, disabled }) => {
     /* eslint-disable no-script-url */

--- a/src/views/components/PrintPage.jsx
+++ b/src/views/components/PrintPage.jsx
@@ -1,6 +1,6 @@
-import PrintPageHeader from './PrintPageHeader';
-import PropTypes from 'prop-types';
-import React from 'react';
+const PrintPageHeader = require('./PrintPageHeader');
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const PrintPage = ({ children, index, title, label }) => {
     return (

--- a/src/views/components/PrintPageHeader.jsx
+++ b/src/views/components/PrintPageHeader.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const PrintPageHeader = ({ children }) => {
     return <div className="PrintPageHeader">{children}</div>;

--- a/src/views/components/PrintableBackground.jsx
+++ b/src/views/components/PrintableBackground.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const PrintableBackground = ({ color }) => {
     return (

--- a/src/views/components/ProfilePhoto.jsx
+++ b/src/views/components/ProfilePhoto.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const ProfilePhoto = ({ imageUrlSet }) => {
     const mediaQueries = ['(max-width: 539px)', '(min-width: 540px)'];

--- a/src/views/components/Street.jsx
+++ b/src/views/components/Street.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+const PropTypes = require('prop-types');
+const React = require('react');
 
 const Street = ({ title }) => {
     return (


### PR DESCRIPTION
In order to support a mixed TypeScript/JavaScript/ES.next codebase, we must reserve usage of `import` for ES6 modules.